### PR TITLE
[ROUTING] Middleware support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,43 @@
 # ClientRouter
 
-`ClientRouter` is a work in progress. Stay tuned for docs.
+`ClientRouter` is an ExpressJS like client side router. It grabs a hold on the 
+url when the user uses a link to navigate. This is intended to help progressive 
+web apps manage the frontend independant of a server call. It uses the browser's
+`history` API to control the pushing and poping of the page state.
+
+It is also a work in progress. Stay tuned for better docs.
+
+## Setup and usage
+
+`ClientRouter` is an es6 class. Import it like you would any other module. After 
+setting up your routes (See [below](#route-matching)), register the router on the
+window. 
+
+```js
+import { ClientRouter } from '../client-router.js';
+const router = new ClientRouter();
+
+... // add route handling in here
+
+router.registerOn(window);    
+```
+
+### Options
+
+`<<<<<<<<<<<<<<<<<<<<< TODO >>>>>>>>>>>>>>>>>>>>`
+```js
+let options = {
+  routerId: 'my-cool-client-router', // unique identifier between apps
+  debug: true,                       // show additional logging info
+}
+
+const router = new ClientRouter(options);
+```
+
+
+### Route matching
+
+`<<<<<<<<<<<<<<<<<<<<< TODO >>>>>>>>>>>>>>>>>>>>`
+
+### Middleware
+`<<<<<<<<<<<<<<<<<<<<< TODO >>>>>>>>>>>>>>>>>>>>`

--- a/client-router.js
+++ b/client-router.js
@@ -1,0 +1,136 @@
+/*******************************************************************************
+* @class stores the state of the route and used to track page state
+*******************************************************************************/
+class Context {
+  constructor (url = "", routerId) {
+    this.url = url;
+    let fullPath;
+    if (url.includes('://')) {
+      let [proto, rest] = url.split("://");
+      this.protocol = proto;
+      fullPath = rest.substr(rest.indexOf('/'))
+    } else {
+      fullPath = url;
+    }
+    let [path, search] = fullPath.split('?');
+    this.path = path || '';
+    this.routerId = routerId;
+    this.collectSearchParams(search);
+  }
+  
+  collectSearchParams (search) {
+    this.search = search || '';
+    if (!search) return;
+    let params = {};
+    search.split('&').forEach(pair => {
+      if (pair.includes("=")) {
+        let [key, value] = pair.split('=');
+        params[key] = value;
+      }
+    })
+    this.search.params = params; 
+  }
+}
+
+/*******************************************************************************
+* @class fires a set of middleware callbacks when a Context matches its route
+*******************************************************************************/
+class RouteHandler {
+  constructor (path, actions) {
+    this.path = path;
+    this.actions = actions;
+  }
+
+  matches (context) {
+    // TODO: better matching
+    if (context.path === this.path) {
+      this.fireActions(context);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  fireActions (context) {
+    let idx = 0;
+    let next = () => {
+      let fn = this.actions[idx++];
+      fn && fn(context, next);
+    }
+    next();
+  }
+}
+
+/*******************************************************************************
+* @exports ClientRouter
+* @class manages the client routing on the window
+*******************************************************************************/
+export class ClientRouter {
+  constructor (options) {
+    options = options || {};
+    this.routerId = options.routerId || Math.random();
+    this.debug = !(options.debug); // TODO: <---
+    this.registrar = [];
+  }
+
+  use (path, ...actions) {
+    this.registrar.push(new RouteHandler(path, actions));
+  }
+
+  registerOn(window) {
+    let onclick = window.document.ontouchstart ? 'touchstart' : 'click';
+    window.addEventListener(onclick, this._onClick.bind(this));
+    window.addEventListener('pushstate', this._onPushState.bind(this));
+    window.addEventListener('popstate', this._onPopState.bind(this));
+    this.debug && console.log(`Router {${this.routerId}} registered to`, window);
+  }
+
+  _onClick (e) {
+    if (e.metaKey || e.ctrlKey || e.shiftKey) return;
+    if (e.defaultPrevented) return;
+    
+    
+    // Get the href of the <a> tag
+    let target = e.target;
+    let domPath = e.path || e.composedPath(); // FF needs composedPath()
+    
+    if (domPath) {
+      for (let i = 0; i < domPath.length; i++) {
+        if (domPath[i].href && domPath[i].nodeName === 'A') {
+          target = domPath[i];
+          break;
+        }
+      }
+    }
+    
+    let path = target.href;
+    if (!path) return;
+    
+    e.preventDefault();
+    this.evalute(new Context(path, this.routerId));
+  }
+
+  _onPushState (e) {
+    console.warn('ClientRouter::onPushState NOT IMPLEMENTED');
+    debugger;
+  }
+
+  _onPopState (e) {
+    console.warn('ClientRouter::onPopState NOT IMPLEMENTED');
+    debugger;
+  }
+  
+  evalute (context) {
+    for (let i = 0; i < this.registrar.length; i++) {
+      if (this.registrar[i].matches(context)) {
+        this.pushState(context);
+        return;
+      }
+    }
+    window.location = context.url;
+  }
+  
+  pushState (context) {
+    window.history.pushState(context, null, context.path)
+  }
+}

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,49 @@
+<html>
+
+<head>
+  <script type="module">
+    import { ClientRouter } from '../client-router.js';
+    let router = new ClientRouter();
+
+
+    const middleware1 = (context, next) => {
+      console.log("CLIENT-SIDE ROUTING TO: ", context.path);
+      context.logged = true; // should modify the context for the next middleware
+      next();
+    };
+    const middleware2 = (context, next) => {
+      console.log(context);
+      next();
+    };
+
+
+    router.use('/page', middleware1, middleware2, (context) => {
+      document.getElementById('page-title').innerHTML = "Default Page";
+    });
+    router.use(`/page/:num`, middleware1, middleware2, (context) => {
+      document.getElementById('page-title').innerHTML = "Page " + context.params.num;
+    });
+
+    router.use(`/:section(about|contact)`, middleware1, middleware2, (context) => {
+      document.getElementById('page-title').innerHTML = context.params.section + " page";
+    });
+
+    router.registerOn(window);    
+  </script>
+</head>
+
+<body>
+  <h1 id="page-title">DEMO PAGE</h1>
+
+  <p><a href="/demo/index.html">/demo/index.html (should reload)</a></p>
+  <br>
+  <p><a href="/page">/page</a></p>
+  <p><a href="/page/1">/page/1</a></p>
+  <p><a href="/page/2">/page/2</a></p>
+  <p><a href="/page/3">/page/3</a></p>
+  <br>
+  <p><a href="/about">/about</a></p>
+  <p><a href="/contact">/contact</a></p>
+</body>
+
+</html>


### PR DESCRIPTION
The `ClientRouter` now fires middleware on routes that match the registered path in the `RouteHandler`. Paths that do not match defer to the server to resolve.

**Example**:
```js
import { ClientRouter } from '../client-router.js';
const router = new ClientRouter();

const loggerMiddleware = (context, next) => {
   console.log(context.path);
   next();
}

router.use('/about', loggerMiddleware, (context) => {
   document.getElementById('page-title').innerHTML = "About Page";
});

router.registerOn(window); 
```
```html
<a href="/about">Go to About page</a>
<a href="/home">Go to Home page</a>
```
In this example, [Go to About page](#) will route on the client's side, and [Go to Home page](#) will defer to the server to resolve.


There is also a demo page for development and testing.

