### PR TITLE
 [TOKENIZED PATH] better match and parameterize a route

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,39 @@ const router = new ClientRouter(options);
 
 ### Route matching
 
-`<<<<<<<<<<<<<<<<<<<<< TODO >>>>>>>>>>>>>>>>>>>>`
+Route matching follows a similar pattern as express. You can match literal routes
+or a tokenized route that populates the `Context` with parameters.
+
+```js
+// render a page on a literal path matching
+router.use('/about', renderYourAboutPageCB);
+```
+
+```js
+router.use('/:section/:subSection', (context) => {
+  
+  // prefixing a path section with ':' will name that section in `context.params` 
+  let section = context.params.section;
+  let subSection = context.params.subSection;
+
+  // now you can use the grepped data to apply on your app.
+  renderYourPageCB(section, subSection);
+
+});
+```
+
+You can append a parameter declaration with `(` `)` to specify a regex pattern
+to enforce a match.
+
+```js
+router.use('/:section(home|about)/:subSection', (context) => {
+  // now, the path will only ever match if the `section` is 'home' or 'about'
+  let section = context.params.section;
+
+  ...
+  
+});
+```
 
 ### Middleware
 `<<<<<<<<<<<<<<<<<<<<< TODO >>>>>>>>>>>>>>>>>>>>`

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,7 +3,7 @@
 <head>
   <script type="module">
     import { ClientRouter } from '../client-router.js';
-    let router = new ClientRouter();
+    let router = new ClientRouter({ routerId: 'demo-router', debug: true });
 
 
     const middleware1 = (context, next) => {
@@ -12,7 +12,7 @@
       next();
     };
     const middleware2 = (context, next) => {
-      console.log(context);
+      console.log('{PARAMS}:', context.params);
       next();
     };
 
@@ -20,12 +20,17 @@
     router.use('/page', middleware1, middleware2, (context) => {
       document.getElementById('page-title').innerHTML = "Default Page";
     });
+
     router.use(`/page/:num`, middleware1, middleware2, (context) => {
       document.getElementById('page-title').innerHTML = "Page " + context.params.num;
     });
 
     router.use(`/:section(about|contact)`, middleware1, middleware2, (context) => {
       document.getElementById('page-title').innerHTML = context.params.section + " page";
+    });
+
+    router.use(`/:section(about|contact)/:subsection`, middleware1, middleware2, (context) => {
+      document.getElementById('page-title').innerHTML = context.params.section + " page | " + context.params.subsection;
     });
 
     router.registerOn(window);    
@@ -38,12 +43,18 @@
   <p><a href="/demo/index.html">/demo/index.html (should reload)</a></p>
   <br>
   <p><a href="/page">/page</a></p>
+  <p><a href="/page/">/page/</a></p>
+  <br>
   <p><a href="/page/1">/page/1</a></p>
   <p><a href="/page/2">/page/2</a></p>
   <p><a href="/page/3">/page/3</a></p>
   <br>
   <p><a href="/about">/about</a></p>
   <p><a href="/contact">/contact</a></p>
+  <br>
+  <p><a href="/contact/pictures">/contact/pictures</a></p>
+  <br>
+  <p><a href="/should/404">/should/404</a></p>
 </body>
 
 </html>


### PR DESCRIPTION
Added `TokenizedPath` to better match paths and grep data from the path.


Route matching follows a similar pattern as express. You can match literal routes
or a tokenized route that populates the `Context` with parameters.

```js
// render a page on a literal path matching
router.use('/about', renderYourAboutPageCB);
```

```js
router.use('/:section/:subSection', (context) => {
  
  // prefixing a path section with ':' will name that section in `context.params` 
  let section = context.params.section;
  let subSection = context.params.subSection;

  // now you can use the grepped data to apply on your app.
  renderYourPageCB(section, subSection);

});
```

You can append a parameter declaration with `(` `)` to specify a regex pattern
to enforce a match.

```js
router.use('/:section(home|about)/:subSection', (context) => {
  // now, the path will only ever match if the `section` is 'home' or 'about'
  let section = context.params.section;

  ...
  
});
```
