### PR TITLE
[DerivedSubpath] added subpath derivation to the routing tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,44 @@ let loggingMiddleware = (context, next) => {
 router.use('/:view', loggingMiddleware, renderYourAboutPageCB);
 ```
 
+## Derived Subpaths
+
+A `DerivedSubpath` allows for a route to specify default values derived from a 
+given callback. The callback for the DerivedSubpath can return an `async` object 
+or a `String`. This is especially useful for forwarding to fully qualified paths 
+in your app. 
+
+Here is an example:
+
+```js
+let defaultSection = new DerivedSubpath('section', (context) => {
+  return 'main'; // or whatever you need to do to compute the default `section`
+})
+router.use(defaultSection);
+
+...
+
+router.use('/page/$:section(main|about|contact)', renderPageSectionCB)
+```
+
+By this pinciple, the following are equivilant:
+
+```js
+router.use('/page', (context) => {
+  router.redirect(`/page/main`);
+})
+router.use('/page/:section(main|about|contact)', (context) => {
+  router.redirect(`/page/${context.params.section}/default`);
+});
+router.use('/page/:section(main|about|contact)/:subsection', renderPageCB);
+```
+
+and 
+
+```js
+router.use(new DerivedSubpath('section',    _ => 'main'));
+router.use(new DerivedSubpath('subsection', _ => 'default'));
+router.use('/page/$:section(main|about|contact)/$:subsection', renderPageCB);
+```
+
+The later being easier to read and understand by the developer than the former.

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,5 +1,10 @@
 <html>
   <head>
+    <style>
+    p {
+      margin: 0;
+    }
+    </style>
   </head>
   <body>
     <script type="module" src="./routing-demo.js"></script>  
@@ -23,8 +28,17 @@
     <br>
     <p><a href="/contact/pictures">/contact/pictures</a></p>
     <br>
-    <p><a href="/should/404">/should/404</a></p>
+    <p><a href="/derived-subpath">/derived-subpath</a></p>
+    <p><a href="/derived-subpath/">/derived-subpath/</a></p>
+    <p><a href="/derived-subpath/blue">/derived-subpath/blue</a></p>
+    <br>
+    <p><a href="/multi-derived-subpath">/multi-derived-subpath</a></p>
+    <p><a href="/multi-derived-subpath/">/multi-derived-subpath/</a></p>
+    <p><a href="/multi-derived-subpath/abc">/multi-derived-subpath/abc</a></p>
+    <p><a href="/multi-derived-subpath/abc/s1">/multi-derived-subpath/abc/s1</a></p>
+    <p><a href="/multi-derived-subpath/abc/s1/s2">/multi-derived-subpath/abc/s1/s2</a></p>
     <br>
     <p><a href="https://google.com">google.com</a></p>
+    <p><a href="/should/404">/should/404</a></p>
   </body>
 </html>

--- a/demo/routing-demo.js
+++ b/demo/routing-demo.js
@@ -1,4 +1,4 @@
-import { ClientRouter } from '../client-router.js';
+import { ClientRouter, RouteHandler, DerivedSubpath } from '../client-router.js';
 let router = new ClientRouter({ routerId: 'demo-router', debug: true });
 
 
@@ -13,9 +13,13 @@ const middleware2 = (context, next) => {
 };
 
 
-router.use('/demo', middleware1, middleware2, (context) => {
+let demoRouteHandler = new RouteHandler('/demo', [middleware1, middleware2, (context) => {
   document.getElementById('page-title').innerHTML = "DEMO";
-});
+}]);
+
+router.use(demoRouteHandler);
+
+
 router.use('/page', middleware1, middleware2, (context) => {
   document.getElementById('page-title').innerHTML = "Default Page";
 });
@@ -30,6 +34,32 @@ router.use(`/:section(about|contact)`, middleware1, middleware2, (context) => {
 
 router.use(`/:section(about|contact)/:subsection`, middleware1, middleware2, (context) => {
   document.getElementById('page-title').innerHTML = context.params.section + " page | " + context.params.subsection;
+});
+
+router.use(new DerivedSubpath('subsection', (context) => {
+  return Promise.resolve('default-path');
+}))
+
+router.use(`/derived-subpath/$:subsection`, middleware1, middleware2, (context) => {
+  document.getElementById('page-title').innerHTML = "DerivedSubpath: " + context.params.subsection;
+});
+
+
+router.use(new DerivedSubpath('first', (context) => {
+  return Promise.resolve('abc');
+}))
+router.use(new DerivedSubpath('second', (context) => {
+  return 'sub-sub-page';
+}))
+router.use(new DerivedSubpath('third', (context) => {
+  return 's0';
+}))
+
+router.use(`/multi-derived-subpath/$:first(abc|123)/$:second/$:third`, middleware1, middleware2, (context) => {
+  document.getElementById('page-title').innerHTML = "Muiltiple DerivedSubpath: " 
+    + context.params.first + " -> " 
+    + context.params.second + " -> " 
+    + context.params.third;
 });
 
 router.registerOn(window);

--- a/upcomming.md
+++ b/upcomming.md
@@ -5,23 +5,3 @@ will be recorded for later project ideas in the form of docs to aid in our goal
 of Design Driven Development. Features described in this document will be moved
 to the main README.md file once support is added.
 
-## Derived Subpaths
-
-A `DerivedSubpath` will namespace a subroute default derivation to a fully 
-qualified path.
-
-Prefixing a tokenized route with `$` will envoke that DerivedSubpath callback 
-used by the router, and replace that part of the path with the derived value 
-from the callback.
-
-
-```js
-let defaultSection = new DerivedSubpath('section', (context) => {
-  return 'main'; // or whatever you need to do to compute the default `section`
-})
-router.use(defaultSection);
-
-...
-
-router.use('/page/$:section(main|about|contact)', renderPageSectionCB)
-```


### PR DESCRIPTION
## Derived Subpaths

A `DerivedSubpath` allows for a route to specify default values derived from a 
given callback. The callback for the DerivedSubpath can return an `async` object 
or a `String`. This is especially useful for forwarding to fully qualified paths 
in your app. 

Here is an example:

```js
let defaultSection = new DerivedSubpath('section', (context) => {
  return 'main'; // or whatever you need to do to compute the default `section`
})
router.use(defaultSection);

...

router.use('/page/$:section(main|about|contact)', renderPageSectionCB)
```

By this pinciple, the following are equivilant:

```js
router.use('/page', (context) => {
  router.redirect(`/page/main`);
})
router.use('/page/:section(main|about|contact)', (context) => {
  router.redirect(`/page/${context.params.section}/default`);
});
router.use('/page/:section(main|about|contact)/:subsection', renderPageCB);
```

and 

```js
router.use(new DerivedSubpath('section',    _ => 'main'));
router.use(new DerivedSubpath('subsection', _ => 'default'));
router.use('/page/$:section(main|about|contact)/$:subsection', renderPageCB);
```

The later being easier to read and understand by the developer than the former.