### PR TITLE
Miscellaneous Additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ router.use('/:view', loggingMiddleware, renderYourAboutPageCB);
 
     <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< TODO >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
+_Explain what `?` does_
+
+_Explain what `*` does_
+
 
 ## Derived Subpaths
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ let options = {
 const router = new ClientRouter(options);
 ```
 
+### `ClientRoute.use()`
+
+  <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< TODO >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+_Explain how `.use()` handles the following:_
+- Strings
+- Arrays
+- DerrivedSubpath
+- RouteHandler 
 
 ### Route matching
 

--- a/client-router.js
+++ b/client-router.js
@@ -158,6 +158,10 @@ export class ClientRouter {
       this.subpaths[firstArg.name] = firstArg.callback;
     } else if (firstArg instanceof RouteHandler) {
       this.registerHandlers(firstArg);
+    } else if (firstArg instanceof Array) {
+      firstArg.forEach(item => {
+        this.use(item, ...actions);
+      });
     } else if (typeof firstArg === 'string') {
       this.registerHandlers(new RouteHandler(firstArg, actions));
     }

--- a/demo/index.html
+++ b/demo/index.html
@@ -40,8 +40,8 @@
     <br>
     <p><a href="/bacon/star">/bacon/star</a></p>
     <p><a href="/thing/star/whatever">/thing/star/whatever</a></p>
-    <!-- <p><a href="/start">/start</a></p> -->
-    <!-- <p><a href="/start/bear">/start/bear</a></p> -->
+    <p><a href="/start">/start</a></p>
+    <p><a href="/start/bear">/start/bear</a></p>
     <br>
     <p><a href="https://google.com">google.com</a></p>
     <p><a href="/should/404">/should/404</a></p>

--- a/demo/index.html
+++ b/demo/index.html
@@ -38,6 +38,11 @@
     <p><a href="/multi-derived-subpath/abc/s1">/multi-derived-subpath/abc/s1</a></p>
     <p><a href="/multi-derived-subpath/abc/s1/s2">/multi-derived-subpath/abc/s1/s2</a></p>
     <br>
+    <p><a href="/bacon/star">/bacon/star</a></p>
+    <p><a href="/thing/star/whatever">/thing/star/whatever</a></p>
+    <!-- <p><a href="/start">/start</a></p> -->
+    <!-- <p><a href="/start/bear">/start/bear</a></p> -->
+    <br>
     <p><a href="https://google.com">google.com</a></p>
     <p><a href="/should/404">/should/404</a></p>
   </body>

--- a/demo/routing-demo.js
+++ b/demo/routing-demo.js
@@ -51,12 +51,8 @@ router.use(`/multi-derived-subpath/$:first(abc|123)/$:second/$:third`, middlewar
   + context.params.third;
 });
 
-router.use('/:path/star*', middleware1, middleware2, (context) => {
+router.use(['/:path/star*', '/star*'], middleware1, middleware2, (context) => {
   document.getElementById('page-title').innerHTML = context.path;
 })
-
-// router.use(['/abc', '/123'], () => {
-//   document.getElementById('page-title').innerHTML = '/abc || /123';
-// })
 
 router.registerOn(window);

--- a/demo/routing-demo.js
+++ b/demo/routing-demo.js
@@ -46,9 +46,17 @@ router.use(new DerivedSubpath('second', _ => { return 'sub-sub-page'; }))
 router.use(new DerivedSubpath('third',  _ => { return 's0'; }))
 router.use(`/multi-derived-subpath/$:first(abc|123)/$:second/$:third`, middleware1, middleware2, (context) => {
   document.getElementById('page-title').innerHTML = "Muiltiple DerivedSubpath: " 
-    + context.params.first + " -> " 
-    + context.params.second + " -> " 
-    + context.params.third;
+  + context.params.first + " -> " 
+  + context.params.second + " -> " 
+  + context.params.third;
 });
+
+router.use('/:path/star*', middleware1, middleware2, (context) => {
+  document.getElementById('page-title').innerHTML = context.path;
+})
+
+// router.use(['/abc', '/123'], () => {
+//   document.getElementById('page-title').innerHTML = '/abc || /123';
+// })
 
 router.registerOn(window);


### PR DESCRIPTION
- Path string can now be a stand alone `RegExp` formatted string
- `/path*` with qualify for `/path` followed by anything (or nothing).
- The `ClientRouter.use()` function now accepts `Array`s of items as the first argument 